### PR TITLE
Update August 2025

### DIFF
--- a/private-zones.json
+++ b/private-zones.json
@@ -295,10 +295,10 @@
             "privateDnsZoneName": ["privatelink.monitor.azure.com", "privatelink.oms.opinsights.azure.com", "privatelink.ods.opinsights.azure.com", "privatelink.agentsvc.azure-automation.net", "privatelink.blob.core.windows.net"]
         },
         {
-            "resource": "Cognitive Services",
+            "resource": "AI Foundry",
             "privateLinkResourceType": "Microsoft.CognitiveServices/accounts",
             "subresource": "account",
-            "privateDnsZoneName": ["privatelink.cognitiveservices.azure.com", "privatelink.openai.azure.com"]
+            "privateDnsZoneName": ["privatelink.cognitiveservices.azure.com", "privatelink.openai.azure.com", "privatelink.services.ai.azure.com"]
         },
         {
             "resource": "Azure File Sync",

--- a/private-zones.json
+++ b/private-zones.json
@@ -295,7 +295,7 @@
             "privateDnsZoneName": ["privatelink.monitor.azure.com", "privatelink.oms.opinsights.azure.com", "privatelink.ods.opinsights.azure.com", "privatelink.agentsvc.azure-automation.net", "privatelink.blob.core.windows.net"]
         },
         {
-            "resource": "AI Foundry",
+            "resource": "Azure AI services",
             "privateLinkResourceType": "Microsoft.CognitiveServices/accounts",
             "subresource": "account",
             "privateDnsZoneName": ["privatelink.cognitiveservices.azure.com", "privatelink.openai.azure.com", "privatelink.services.ai.azure.com"]

--- a/provider.tf
+++ b/provider.tf
@@ -1,16 +1,14 @@
 terraform {
+  required_version = ">= 1.0.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.0"
+      version = "~>4.0"
     }
   }
 }
 
 provider "azurerm" {
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-  }
+  features {}
+  subscription_id = var.subscription_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,23 @@
+variable "subscription_id" {
+  description = "The ID of the Azure subscription where the resources will be created."
+  type        = string
+}
+
 variable "location" {
+  description = "The Azure region where the resources will be created."
   type = string
   default = "westeurope"
 }
 
 variable "resource_group_dns_name" {
+  description = "Name of the resource group"
   type = string
-  default = "private-dns-zones-rg"
+  default = "rg-dns-priv-001"
 }
 
 variable "user_assigned_identity_name" {
   type = string
-  default = "dns-remediation-managed-identity"
+  default = "mi-dns-remediation"
 }
 
 variable "deny_prive_dns_zone_creation" {


### PR DESCRIPTION
This pull request updates the Terraform configuration and supporting files to improve Azure provider compatibility, add configurability, and expand DNS zone support. The most significant changes are upgrading the Azure provider version, introducing a configurable subscription ID, and updating resource naming conventions.

**Terraform provider and configuration updates:**

* Upgraded the `azurerm` provider version from `~>3.0` to `~>4.0` in `provider.tf` for better compatibility with newer Azure features. Also set a minimum Terraform version of 1.0.0.
* Added a new `subscription_id` variable in `variables.tf` and updated the `provider "azurerm"` block to use it, allowing selection of the target Azure subscription via configuration. [[1]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR1-R20) [[2]](diffhunk://#diff-b1ce465309ea8053579092908d4a1eda1a02f48a6287db574dd2a2104935dd2fR2-R13)

**Resource naming and documentation improvements:**

* Updated default values for `resource_group_dns_name` and `user_assigned_identity_name` variables to new naming conventions, and added descriptions for better clarity.

**Private DNS zone enhancements:**

* In `private-zones.json`, renamed the "Cognitive Services" resource to "Azure AI services" and added a new DNS zone, `privatelink.services.ai.azure.com`, to the list of private DNS zones for this resource.
* Link with issue #7 